### PR TITLE
Add `onload`

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -95,6 +95,16 @@ class Cloud {
       this.waits.push([target.startsWith('☁ ')?target: '☁ '+target, targetFn, resolve]);
     });
   }
+  
+  onload(target, callback) {
+    if(!callback) {
+      return new Promise((resolve, reject) => {
+        this.waits.push([target.startsWith('☁ ')?target: '☁ '+target, ((val) => val != undefined), resolve]);
+      });
+    } else {
+      this.waits.push([target.startsWith('☁ ')?target: '☁ '+target, ((val) => val != undefined), callback]);      
+    }
+  }
 }
 
 Cloud.createAsync = (user, id) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scratchcloud",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scratchcloud",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A powerful Node.js library for Scratch cloud manipulation",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Fixes #6 

This does need testing though.

It should work in the following ways:
```js
await cloud.onload("variable");
```
```js
cloud.onload("variable").then(() => { /* your code */ });
```
```js
cloud.onload("variable", () => { /* your code */ });
```